### PR TITLE
Alternative location for zita-convolver, fixes bootstrap

### DIFF
--- a/plugins-dep/package/zita-convolver/zita-convolver.mk
+++ b/plugins-dep/package/zita-convolver/zita-convolver.mk
@@ -5,7 +5,7 @@
 ################################################################################
 
 ZITA_CONVOLVER_VERSION = 3.1.0
-ZITA_CONVOLVER_SITE = http://http.debian.net/debian/pool/main/z/zita-convolver
+ZITA_CONVOLVER_SITE = http.debian.net/debian/pool/main/z/zita-convolver
 ZITA_CONVOLVER_SOURCE = zita-convolver_$(ZITA_CONVOLVER_VERSION).orig.tar.bz2
 ZITA_CONVOLVER_DEPENDENCIES = ffmpeg
 ZITA_CONVOLVER_LICENSE = GPLv3+

--- a/plugins-dep/package/zita-convolver/zita-convolver.mk
+++ b/plugins-dep/package/zita-convolver/zita-convolver.mk
@@ -5,8 +5,8 @@
 ################################################################################
 
 ZITA_CONVOLVER_VERSION = 3.1.0
-ZITA_CONVOLVER_SITE = http://kokkinizita.linuxaudio.org/linuxaudio/downloads
-ZITA_CONVOLVER_SOURCE = zita-convolver-$(ZITA_CONVOLVER_VERSION).tar.bz2
+ZITA_CONVOLVER_SITE = http://http.debian.net/debian/pool/main/z/zita-convolver
+ZITA_CONVOLVER_SOURCE = zita-convolver_$(ZITA_CONVOLVER_VERSION).orig.tar.bz2
 ZITA_CONVOLVER_DEPENDENCIES = ffmpeg
 ZITA_CONVOLVER_LICENSE = GPLv3+
 ZITA_CONVOLVER_INSTALL_STAGING = YES


### PR DESCRIPTION
Fons took down previous releases, which breaks MPB.
Use debian archives as alternative.