### PR TITLE
Update setbfree to 0.8.10

### DIFF
--- a/plugins/package/setbfree/setbfree.mk
+++ b/plugins/package/setbfree/setbfree.mk
@@ -4,7 +4,7 @@
 #
 ######################################
 
-SETBFREE_VERSION = 30f1ec6267afb0ee17b472db0c4826d5bd96fad8
+SETBFREE_VERSION = 8535a15bfe9832f50f5da53039c1af01cacfb992
 SETBFREE_SITE = $(call github,pantherb,setBfree,$(SETBFREE_VERSION))
 SETBFREE_DEPENDENCIES = fftw-single libsndfile zita-convolver
 SETBFREE_BUNDLES = b_overdrive b_reverb b_synth b_whirl b_whirl_xt
@@ -12,19 +12,14 @@ SETBFREE_BUNDLES = b_overdrive b_reverb b_synth b_whirl b_whirl_xt
 SETBFREE_TARGET_MAKE = $(TARGET_MAKE_ENV) $(TARGET_CONFIGURE_OPTS) $(MAKE) MOD_BUILD=1 OPTIMIZATIONS= PREFIX=/usr -C $(@D)
 
 define SETBFREE_BUILD_CMDS
-	$(SETBFREE_TARGET_MAKE)
+	$(SETBFREE_TARGET_MAKE) MOD=True
 endef
 
 define SETBFREE_INSTALL_TARGET_CMDS
-	$(SETBFREE_TARGET_MAKE) install DESTDIR=$(TARGET_DIR)
-	cp -rL $($(PKG)_PKGDIR)/b_overdrive/* $(TARGET_DIR)/usr/lib/lv2/b_overdrive/
-	cp -rL $($(PKG)_PKGDIR)/b_reverb/*    $(TARGET_DIR)/usr/lib/lv2/b_reverb/
-	cp -rL $($(PKG)_PKGDIR)/b_synth/*     $(TARGET_DIR)/usr/lib/lv2/b_synth/
-	
+	$(SETBFREE_TARGET_MAKE) install DESTDIR=$(TARGET_DIR) MOD=True
+
 	# b_whirl has been manually splitted into separate bundles
 	mv $(TARGET_DIR)/usr/lib/lv2/b_whirl/b_whirl.so $(TARGET_DIR)/usr/lib/lv2/b_whirl.so
-	rm -rf $(TARGET_DIR)/usr/lib/lv2/b_whirl/
-	cp -rL $($(PKG)_PKGDIR)/b_whirl    $(TARGET_DIR)/usr/lib/lv2/
 	cp -rL $($(PKG)_PKGDIR)/b_whirl_xt $(TARGET_DIR)/usr/lib/lv2/
 	cp $(TARGET_DIR)/usr/lib/lv2/b_whirl.so $(TARGET_DIR)/usr/lib/lv2/b_whirl/
 	cp $(TARGET_DIR)/usr/lib/lv2/b_whirl.so $(TARGET_DIR)/usr/lib/lv2/b_whirl_xt/


### PR DESCRIPTION
Hi,

Here is an update for setBfree. FIles from lv2 data should not be needed anymore.

Files looks to be well generated, but when I deployed them to ModDuoX, i don't have the expected rendering for `synth` and `whirl`, while the `overdrive` and `reverb` are fine.

If i reach back the files and check the rendering with modsdk it's fine.

If somebody could have a look, or have an idea, it can be very useful.