### PR TITLE
Set zynaddsubfx rootdir, and copy banks to lv2 bundle

### DIFF
--- a/plugins/package/zynaddsubfx-labs/11_mod-path-tweaks.patch
+++ b/plugins/package/zynaddsubfx-labs/11_mod-path-tweaks.patch
@@ -1,0 +1,46 @@
+diff --git a/src/Misc/Config.cpp b/src/Misc/Config.cpp
+index 5bd1976c..0b44765e 100644
+--- a/src/Misc/Config.cpp
++++ b/src/Misc/Config.cpp
+@@ -230,6 +230,11 @@ void Config::init()
+     getConfigFileName(filename, MAX_STRING_SIZE);
+     readConfig(filename);
+ 
++#ifdef __MOD_DEVICES__
++    cfg.currentBankDir = cfg.bankRootDirList[0] = ZYN_DATADIR "/banks";
++    cfg.presetsDirList[0] = ZYN_DATADIR "/presets";
++    cfg.IgnoreProgramChange = true;
++#else
+     if(cfg.bankRootDirList[0].empty()) {
+         //banks
+         cfg.bankRootDirList[0] = "~/banks";
+@@ -264,6 +269,7 @@ void Config::init()
+         cfg.presetsDirList[4] = "/usr/local/share/zynaddsubfx/presets";
+ #endif
+     }
++#endif
+     cfg.LinuxALSAaudioDev = "default";
+     cfg.nameTag = "";
+ }
+diff --git a/src/Misc/MiddleWare.cpp b/src/Misc/MiddleWare.cpp
+index 49bce2ca..37dcfa42 100644
+--- a/src/Misc/MiddleWare.cpp
++++ b/src/Misc/MiddleWare.cpp
+@@ -1338,6 +1338,9 @@ static rtosc::Ports middwareSnoopPorts = {
+         rEnd},
+     {"file_home_dir:", 0, 0,
+         rBegin;
++#ifdef __MOD_DEVICES__
++        const char *home = ZYN_DATADIR;
++#else
+         const char *home = getenv("PWD");
+         if(!home)
+             home = getenv("HOME");
+@@ -1347,6 +1350,7 @@ static rtosc::Ports middwareSnoopPorts = {
+             home = getenv("HOMEPATH");
+         if(!home)
+             home = "/";
++#endif
+ 
+         string home_ = home;
+ #ifndef WIN32

--- a/plugins/package/zynaddsubfx-labs/zynaddsubfx-labs.mk
+++ b/plugins/package/zynaddsubfx-labs/zynaddsubfx-labs.mk
@@ -9,9 +9,8 @@ ZYNADDSUBFX_LABS_VERSION = 4d4aedf834dbd13c6e5f07ac512c9da74732fd58
 ZYNADDSUBFX_LABS_SITE = git://git.code.sf.net/p/zynaddsubfx/code
 ZYNADDSUBFX_LABS_SITE_METHOD = git
 ZYNADDSUBFX_LABS_DEPENDENCIES = fftw-single fftw-double mxml liblo zlib
+ZYNADDSUBFX_LABS_CONF_OPTS=-DZYN_DATADIR="/root/.lv2/ZynAddSubFX.lv2"
 ZYNADDSUBFX_LABS_BUNDLES = ZynAddSubFX.lv2 ZynAlienWah.lv2 ZynChorus.lv2 ZynDistortion.lv2 ZynDynamicFilter.lv2 ZynEcho.lv2 ZynPhaser.lv2 ZynReverb.lv2
-
-ZYNADDSUBFX_LABS_TARGET_MAKE = $(TARGET_MAKE_ENV) $(TARGET_CONFIGURE_OPTS) $(MAKE) VERBOSE=1 -C $(@D)
 
 # needed for git submodules
 define ZYNADDSUBFX_LABS_EXTRACT_CMDS
@@ -23,10 +22,6 @@ define ZYNADDSUBFX_LABS_EXTRACT_CMDS
 	touch $(@D)/.stamp_downloaded
 endef
 
-define ZYNADDSUBFX_LABS_BUILD_CMDS
-	$(ZYNADDSUBFX_LABS_TARGET_MAKE)
-endef
-
 define ZYNADDSUBFX_LABS_POST_INSTALL_TARGET_MODGUIS
 	# presets (clear all first)
 	rm $(TARGET_DIR)/usr/lib/lv2/ZynAddSubFX.lv2/*.ttl
@@ -34,6 +29,9 @@ define ZYNADDSUBFX_LABS_POST_INSTALL_TARGET_MODGUIS
 
 	# modguis
 	cp -rL $($(PKG)_PKGDIR)/ZynAddSubFX.lv2/modgui $(TARGET_DIR)/usr/lib/lv2/ZynAddSubFX.lv2/
+
+	# extra data for native UI niceness
+	cp -rL $(TARGET_DIR)/usr/share/zynaddsubfx/banks $(TARGET_DIR)/usr/lib/lv2/ZynAddSubFX.lv2/
 endef
 
 ZYNADDSUBFX_LABS_POST_INSTALL_TARGET_HOOKS += ZYNADDSUBFX_LABS_POST_INSTALL_TARGET_MODGUIS


### PR DESCRIPTION
The 2nd part of the zynaddsubfx stuff.
With these changes, the native UI can see and load banks/presets from the GUI
