### PR TITLE
Add die-plugins, specially useful for a-fluidsynth

### DIFF
--- a/plugins/package/die-plugins-labs/die-plugins-labs.mk
+++ b/plugins/package/die-plugins-labs/die-plugins-labs.mk
@@ -1,0 +1,22 @@
+######################################
+#
+# die-plugins-labs
+#
+######################################
+
+DIE_PLUGINS_LABS_VERSION = 54052b9ca309250943cdf7b15b5afec2f72a9ce6
+DIE_PLUGINS_LABS_SITE = $(call github,DISTRHO,DIE-Plugins,$(DIE_PLUGINS_LABS_VERSION))
+DIE_PLUGINS_LABS_DEPENDENCIES = fluidsynth libsndfile
+DIE_PLUGINS_LABS_BUNDLES = distrho-a-comp.lv2 distrho-a-delay.lv2 distrho-a-eq.lv2 distrho-a-exp.lv2 distrho-a-reverb.lv2
+
+DIE_PLUGINS_LABS_TARGET_MAKE = $(TARGET_MAKE_ENV) $(TARGET_CONFIGURE_OPTS) $(MAKE) -C $(@D)
+
+define DIE_PLUGINS_LABS_BUILD_CMDS
+	$(DIE_PLUGINS_LABS_TARGET_MAKE)
+endef
+
+define DIE_PLUGINS_LABS_INSTALL_TARGET_CMDS
+	$(DIE_PLUGINS_LABS_TARGET_MAKE) install PREFIX=/usr DESTDIR=$(TARGET_DIR)
+endef
+
+$(eval $(generic-package))

--- a/plugins/package/die-plugins/die-plugins.mk
+++ b/plugins/package/die-plugins/die-plugins.mk
@@ -1,0 +1,22 @@
+######################################
+#
+# die-plugins
+#
+######################################
+
+DIE_PLUGINS_VERSION = 54052b9ca309250943cdf7b15b5afec2f72a9ce6
+DIE_PLUGINS_SITE = $(call github,DISTRHO,DIE-Plugins,$(DIE_PLUGINS_VERSION))
+DIE_PLUGINS_DEPENDENCIES = fluidsynth libsndfile
+DIE_PLUGINS_BUNDLES = distrho-a-fluidsynth.lv2
+
+DIE_PLUGINS_TARGET_MAKE = $(TARGET_MAKE_ENV) $(TARGET_CONFIGURE_OPTS) $(MAKE) -C $(@D)
+
+define DIE_PLUGINS_BUILD_CMDS
+	$(DIE_PLUGINS_TARGET_MAKE)
+endef
+
+define DIE_PLUGINS_INSTALL_TARGET_CMDS
+	$(DIE_PLUGINS_TARGET_MAKE) install PREFIX=/usr DESTDIR=$(TARGET_DIR)
+endef
+
+$(eval $(generic-package))

--- a/plugins/package/fluida-labs/fluida-labs.mk
+++ b/plugins/package/fluida-labs/fluida-labs.mk
@@ -1,0 +1,26 @@
+######################################
+#
+# fluida-labs
+#
+######################################
+
+FLUIDA_LABS_VERSION = f22e828c319a05fe03aaafcd1bdb06a2b63a96c9
+FLUIDA_LABS_SITE = $(call github,brummer10,fluida.lv2,$(FLUIDA_LABS_VERSION))
+FLUIDA_LABS_DEPENDENCIES = fluidsynth
+FLUIDA_LABS_BUNDLES = Fluida.lv2
+
+ifdef BR2_cortex_a7
+FLUIDA_LABS_SSE_CFLAGS = -mfpu=vfpv3
+endif
+
+FLUIDA_LABS_TARGET_MAKE = $(TARGET_MAKE_ENV) $(TARGET_CONFIGURE_OPTS) $(MAKE) SSE_CFLAGS="$(FLUIDA_LABS_SSE_CFLAGS)"
+
+define FLUIDA_LABS_BUILD_CMDS
+	$(FLUIDA_LABS_TARGET_MAKE) -C $(@D) mod
+endef
+
+define FLUIDA_LABS_INSTALL_TARGET_CMDS
+	$(FLUIDA_LABS_TARGET_MAKE) -C $(@D)/Fluida install DESTDIR=$(TARGET_DIR) INSTALL_DIR=/usr/lib/lv2
+endef
+
+$(eval $(generic-package))


### PR DESCRIPTION
Adds die-plugins, a small little project of mine to re-package ardour built-in plugins for our case and whoever also wants.
These plugins are very high quality and polished, but for now it is specially interesting the fluidsynth one.
I am already assuming we will be using it in the stable store, so the package name reflects that (non labs prefix for that one)

Maybe the others are useful too, not sure. Feel free to try.

Added fluida-labs as bonus package, just so we can already have a small start on that.
It does not work well yet, and the a-fluidsynth is pretty much good as-is, so I don't expect this one to replace it.
Still a very useful plugin as all its parameters are done via the new LV2 parameter APIs.
