### PR TITLE
Set device macros in default builroot args

### DIFF
--- a/plugins-dep/configs/modduo_defconfig
+++ b/plugins-dep/configs/modduo_defconfig
@@ -12,7 +12,7 @@ BR2_TOOLCHAIN_EXTERNAL_GCC_4_9=y
 BR2_TOOLCHAIN_EXTERNAL_HEADERS_3_10=y
 BR2_TOOLCHAIN_EXTERNAL_CUSTOM_GLIBC=y
 BR2_TOOLCHAIN_EXTERNAL_CXX=y
-BR2_TARGET_OPTIMIZATION="-mcpu=cortex-a7 -mtune=cortex-a7 -mfpu=neon-vfpv4 -mfloat-abi=hard -mvectorize-with-neon-quad -ffast-math -fno-finite-math-only -fprefetch-loop-arrays -funroll-loops -funsafe-loop-optimizations -D__MOD_DEVICES__"
+BR2_TARGET_OPTIMIZATION="-mcpu=cortex-a7 -mtune=cortex-a7 -mfpu=neon-vfpv4 -mfloat-abi=hard -mvectorize-with-neon-quad -ffast-math -fno-finite-math-only -fprefetch-loop-arrays -funroll-loops -funsafe-loop-optimizations -D__MOD_DEVICES__ -D_MOD_DEVICE_DUO"
 BR2_TARGET_LDFLAGS="-Wl,-O1 -Wl,--as-needed -Wl,--strip-all"
 BR2_TARGET_GENERIC_HOSTNAME=""
 BR2_TARGET_GENERIC_ISSUE=""

--- a/plugins-dep/configs/modduox_defconfig
+++ b/plugins-dep/configs/modduox_defconfig
@@ -10,7 +10,7 @@ BR2_TOOLCHAIN_EXTERNAL_HEADERS_4_3=y
 BR2_TOOLCHAIN_EXTERNAL_CUSTOM_GLIBC=y
 BR2_TOOLCHAIN_EXTERNAL_CXX=y
 BR2_GENERATE_LOCALE="en_US.UTF-8"
-BR2_TARGET_OPTIMIZATION="-mcpu=cortex-a53 -mtune=cortex-a53 -mfix-cortex-a53-835769 -mfix-cortex-a53-843419 -ffast-math -fno-finite-math-only -D__MOD_DEVICES__"
+BR2_TARGET_OPTIMIZATION="-mcpu=cortex-a53 -mtune=cortex-a53 -mfix-cortex-a53-835769 -mfix-cortex-a53-843419 -ffast-math -fno-finite-math-only -D__MOD_DEVICES__ -D_MOD_DEVICE_DUOX"
 BR2_TARGET_LDFLAGS="-Wl,-O1 -Wl,--as-needed -Wl,--strip-all"
 BR2_TARGET_GENERIC_HOSTNAME=""
 BR2_TARGET_GENERIC_ISSUE=""

--- a/plugins-dep/configs/moddwarf_defconfig
+++ b/plugins-dep/configs/moddwarf_defconfig
@@ -11,7 +11,7 @@ BR2_TOOLCHAIN_EXTERNAL_HEADERS_4_4=y
 BR2_TOOLCHAIN_EXTERNAL_CUSTOM_GLIBC=y
 BR2_TOOLCHAIN_EXTERNAL_CXX=y
 BR2_GENERATE_LOCALE="en_US.UTF-8"
-BR2_TARGET_OPTIMIZATION="-mcpu=cortex-a35 -mtune=cortex-a35 -ffast-math -fno-finite-math-only -D__MOD_DEVICES__"
+BR2_TARGET_OPTIMIZATION="-mcpu=cortex-a35 -mtune=cortex-a35 -ffast-math -fno-finite-math-only -D__MOD_DEVICES__ -D_MOD_DEVICE_DWARF"
 BR2_TARGET_LDFLAGS="-Wl,-O1 -Wl,--as-needed -Wl,--strip-all"
 BR2_TARGET_GENERIC_HOSTNAME=""
 BR2_TARGET_GENERIC_ISSUE=""


### PR DESCRIPTION
We should not recommend the use of these, but who knows, might be useful sometime in the future.
The same is already present in MBS, so this just makes it match.

I do not see a need for these flags right now, but we might as well have them in there.

Toolchain/bootstrap/workdir rebuild is necessary again for this, sorry :P
