### PR TITLE
Add notes-lv2 plugin

### DIFF
--- a/plugins/package/notes-lv2/Makefile
+++ b/plugins/package/notes-lv2/Makefile
@@ -1,0 +1,36 @@
+
+VERSION = $(shell cat VERSION)
+MINOR_VERSION = $(word 2, $(subst ., ,$(VERSION)))
+MICRO_VERSION = $(word 3, $(subst ., ,$(VERSION)))
+
+CFLAGS += -I. -Iprops.lv2 -fPIC -Wall -Wextra -std=gnu11 -D_GNU_SOURCE -fvisibility=hidden -DNOTES_VERSION="$(VERSION)"
+LDFLAGS += -Wl,--no-undefined
+
+TARGETS = notes.lv2/notes.so notes.lv2/manifest.ttl notes.lv2/notes.ttl
+
+all: $(TARGETS)
+
+clean:
+	rm -rf notes.lv2 *.o
+
+install: $(TARGETS)
+	install -d $(DESTDIR)/usr/lib/lv2/notes.lv2
+	install -m 644 $(TARGETS) $(DESTDIR)/usr/lib/lv2/notes.lv2
+
+notes.lv2/notes.so: notes.o
+	-mkdir -p $(shell dirname $@)
+	$(CC) $< $(LDFLAGS) -shared -o $@
+
+notes.lv2/manifest.ttl: manifest.ttl.in
+	-mkdir -p $(shell dirname $@)
+	sed $< \
+		-e "s/@MODULE_SUFFIX@/.so/" \
+		-e "s/@MINOR_VERSION@/$(MINOR_VERSION)/" \
+		-e "s/@MICRO_VERSION@/$(MICRO_VERSION)/" > $@
+
+notes.lv2/notes.ttl: notes.ttl
+	-mkdir -p $(shell dirname $@)
+	cp $< $@
+
+notes.o: notes.c
+	$(CC) $< $(CFLAGS) -c -o $@

--- a/plugins/package/notes-lv2/notes-lv2.mk
+++ b/plugins/package/notes-lv2/notes-lv2.mk
@@ -1,0 +1,24 @@
+######################################
+#
+# notes-lv2
+#
+######################################
+
+NOTES_LV2_VERSION = 0.2.0
+NOTES_LV2_SITE = https://git.open-music-kontrollers.ch/lv2/notes.lv2/snapshot
+NOTES_LV2_SOURCE = notes.lv2-$(NOTES_LV2_VERSION).tar.xz
+NOTES_LV2_BUNDLES = notes.lv2
+
+NOTES_LV2_TARGET_MAKE = $(TARGET_MAKE_ENV) $(TARGET_CONFIGURE_OPTS) $(MAKE) -C $(@D)
+
+define NOTES_LV2_BUILD_CMDS
+	cp $($(PKG)_PKGDIR)/Makefile $(@D)/Makefile
+	$(NOTES_LV2_TARGET_MAKE)
+endef
+
+define NOTES_LV2_INSTALL_TARGET_CMDS
+	$(NOTES_LV2_TARGET_MAKE) install DESTDIR=$(TARGET_DIR)
+	cp -rL $($(PKG)_PKGDIR)/notes.lv2/* $(TARGET_DIR)/usr/lib/lv2/notes.lv2/
+endef
+
+$(eval $(generic-package))

--- a/plugins/package/notes-lv2/notes.lv2
+++ b/plugins/package/notes-lv2/notes.lv2
@@ -1,0 +1,1 @@
+../../../lv2-data/plugins-fixed/notes.lv2


### PR DESCRIPTION
Needs latest v1.10 (from today) for the textarea mod-ui fix.
And in the store it will need 1.10 for the state and patch parameter features.

Already working as-is, with some known issues:
- Cannot use quotes " in the text
- Text size seems hardcoded to a limit, not sure where this comes from

Might be useful to get to the store faster so we can leave notes on the default/factory Dwarf pedalboards.
