### PR TITLE
Add macOS M1 / docker / arm64 setup

### DIFF
--- a/.common
+++ b/.common
@@ -40,6 +40,15 @@ if [ -z "${PLATFORM}" ]; then
 fi
 
 #######################################################################################################################
+# check for readlink binary
+
+if [ -f "/opt/local/bin/greadlink" ]; then
+  readlink="/opt/local/bin/greadlink"
+else
+  readlink="readlink"
+fi
+
+#######################################################################################################################
 # crosstool-ng variables
 
 CT_NG_LINK=http://crosstool-ng.org/download/crosstool-ng/
@@ -59,7 +68,7 @@ BUILDROOT_LINK=http://buildroot.uclibc.org/downloads/
 BUILDROOT_VERSION=buildroot-2016.02
 BUILDROOT_FILE=${BUILDROOT_VERSION}.tar.bz2
 
-SOURCE_DIR=$(readlink -f $(dirname $0))
+SOURCE_DIR=$("${readlink}" -f $(dirname $0))
 BR2_MAKE="make O=${WORKDIR}/${PLATFORM} BR2_EXTERNAL=${SOURCE_DIR}/plugins-dep"
 BR2_TARGET=${WORKDIR}/${PLATFORM}/target
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *~
 *.bak
+.DS_Store
 .kdev_include_paths
 kernel
 plugins/package/eg-amp-lv2/source/eg-amp.lv2/amp.so

--- a/docker-arm64/Dockerfile
+++ b/docker-arm64/Dockerfile
@@ -1,0 +1,55 @@
+FROM ubuntu:20.04
+LABEL maintainer="Filipe Coelho <falktx@falktx.com>"
+ENV DEBIAN_FRONTEND noninteractive
+
+# platform argument must be provided, e.g. --build-arg platform=modduo
+ARG platform=moddwarf
+
+# enable armhf
+RUN dpkg --add-architecture armhf
+
+RUN echo "deb [arch=armhf,arm64] http://ports.ubuntu.com/ubuntu-ports focal main restricted universe multiverse"            > /etc/apt/sources.list && \
+    echo "deb [arch=armhf,arm64] http://ports.ubuntu.com/ubuntu-ports focal-updates main restricted universe multiverse"   >> /etc/apt/sources.list && \
+    echo "deb [arch=armhf,arm64] http://ports.ubuntu.com/ubuntu-ports focal-backports main restricted universe multiverse" >> /etc/apt/sources.list
+
+# update and upgrade system
+RUN apt-get update && apt-get upgrade -qy && apt-get clean
+
+# install packages for buildroot
+RUN apt-get install -qy qemu-user-static && \
+    apt-get install -qy libmxml1:armhf libfftw3-3:armhf liblo7:armhf libsndfile1:armhf zlib1g:armhf libstdc++6:armhf && \
+    apt-get install -qy libmxml1:arm64 libfftw3-3:arm64 liblo7:arm64 libsndfile1:arm64 zlib1g:arm64 libstdc++6:arm64 && \
+    apt-get install -qy locales acl bash bash-completion bc curl cvs git mercurial rsync subversion sudo wget dosfstools && \
+    apt-get install -qy bison bundler bzip2 cpio flex gawk gperf gzip help2man nano perl patch python tar texinfo unzip python3-dev python3-setuptools && \
+    apt-get install -qy automake binutils build-essential device-tree-compiler premake4 sunxi-tools libtool-bin ncurses-dev jq && \
+    apt-get clean
+RUN wget http://ports.ubuntu.com/ubuntu-ports/pool/universe/p/premake/premake_3.7-1_arm64.deb && \
+    dpkg -i premake_3.7-1_arm64.deb && \
+    rm premake_3.7-1_arm64.deb
+
+RUN locale-gen en_US.UTF-8
+RUN echo "source /etc/bash_completion" >> $HOME/.bashrc
+
+# user configurations
+ENV USER builder
+ENV HOME /home/$USER
+
+# mod-plugin-builder settings
+ENV MPB_GIT_URL https://github.com/moddevices/mod-plugin-builder
+
+# create user
+RUN useradd -d $HOME -m -G sudo $USER
+# set user to sudoers (no password required)
+RUN echo "$USER ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/99-$USER && chmod 0440 /etc/sudoers.d/99-$USER
+
+# switch user
+USER $USER
+
+# checkout mod-build-system
+WORKDIR $HOME
+RUN git clone $MPB_GIT_URL
+WORKDIR mod-plugin-builder
+RUN ./bootstrap.sh $platform && ./.clean-install.sh $platform
+
+# CMD
+CMD ["bash"]

--- a/docker-mount.sh
+++ b/docker-mount.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+set -e
+
+#######################################################################################################################
+# check arguments
+
+PLATFORM="${1}"
+DOCKER_IMAGE="${2}"
+
+if [[ "${PLATFORM}" == "" ]] || [[ "${DOCKER_IMAGE}" == "" ]]; then
+  echo "Usage: $0 <platform> <docker-image>"
+  echo "  Where platform can be modduo, modduox, moddwarf or x86_64"
+  exit 1
+fi
+
+#######################################################################################################################
+# Import common code and variables
+
+cd $(dirname ${0})
+source .common
+
+#######################################################################################################################
+# Now setup docker mountpoints (or run it if already exists)
+
+if docker ps -a | grep -q "mpb_${PLATFORM}"; then
+  docker start -i "mpb_${PLATFORM}"
+else
+  docker run --name "mpb_${PLATFORM}" -ti -v $(pwd):/home/builder/mod-plugin-builder -v ${PLUGINS_DIR}:/home/builder/mod-workdir/${PLATFORM}/plugins "${DOCKER_IMAGE}"
+fi


### PR DESCRIPTION
This adds a few things:
- arm64 compatible docker file (can be used on macOS, potentially other systems)
- script to auto-mount local MPB and plugin dir in the generated docker image (and will run the instance if already created)

Tested to work on an Apple Mini M1, both docker image building and also publishing of a plugin to a MOD device connected over USB.
