### PR TITLE
Add MetalTone pedal

### DIFF
--- a/plugins/package/metaltone/metaltone.mk
+++ b/plugins/package/metaltone/metaltone.mk
@@ -1,0 +1,27 @@
+######################################
+#
+# metaltone
+#
+######################################
+
+METALTONE_VERSION = d4482b8af7cb66831006dabbff6b679e33cb3d51
+METALTONE_SITE = $(call github,brummer10,MetalTone,$(METALTONE_VERSION))
+METALTONE_BUNDLES = MetalTone.lv2
+
+ifdef BR2_cortex_a7
+METALTONE_SSE_CFLAGS = -mfpu=vfpv3
+else
+METALTONE_SSE_CFLAGS = ""
+endif
+
+METALTONE_TARGET_MAKE = $(TARGET_MAKE_ENV) $(TARGET_CONFIGURE_OPTS) $(MAKE)  SSE_CFLAGS="$(METALTONE_SSE_CFLAGS)" -C $(@D)
+
+define METALTONE_BUILD_CMDS
+	$(METALTONE_TARGET_MAKE) mod
+endef
+
+define METALTONE_INSTALL_TARGET_CMDS
+	$(METALTONE_TARGET_MAKE) install DESTDIR=$(TARGET_DIR) INSTALL_DIR=/usr/lib/lv2
+endef
+
+$(eval $(generic-package))

--- a/plugins/package/metaltone/metaltone.mk
+++ b/plugins/package/metaltone/metaltone.mk
@@ -4,7 +4,7 @@
 #
 ######################################
 
-METALTONE_VERSION = 6613d9953b74a4122acb56d779bcc50ba50ad958
+METALTONE_VERSION = e0868b13238f01b9d347f29eba4d4855a8e091a0
 METALTONE_SITE = $(call github,brummer10,MetalTone,$(METALTONE_VERSION))
 METALTONE_BUNDLES = MetalTone.lv2
 

--- a/plugins/package/metaltone/metaltone.mk
+++ b/plugins/package/metaltone/metaltone.mk
@@ -4,7 +4,7 @@
 #
 ######################################
 
-METALTONE_VERSION = d4482b8af7cb66831006dabbff6b679e33cb3d51
+METALTONE_VERSION = 6613d9953b74a4122acb56d779bcc50ba50ad958
 METALTONE_SITE = $(call github,brummer10,MetalTone,$(METALTONE_VERSION))
 METALTONE_BUNDLES = MetalTone.lv2
 


### PR DESCRIPTION
MetalTone is a High Gain Distortion Pedal with a advanced EQ section.
There are two active EQ controls with a whopping 15dB of cut/boost, as well as a mids control with the same gain and a variable frequency.
The Mid freq has a very wide range, going from 200Hz all the way to 5kHz.
As a result, it's better to think of it simply as a single active EQ control, and disregard the idea it's only for shaping mids. 
