### PR TITLE
Don't hardcode platforms in platform argument validation

### DIFF
--- a/.clean-install.sh
+++ b/.clean-install.sh
@@ -5,16 +5,18 @@
 
 PLATFORM=$1
 
-if [ "${PLATFORM}" == "" ]; then
+cd $(dirname ${0})
+
+if [[ -z "${PLATFORM}" ]] || [[ ! -a "toolchain/${PLATFORM}.config" ]]; then
   echo "Usage: $0 <platform>"
-  echo "  Where platform can be modduo[-static], modduox[-static], moddwarf or x86_64"
+  echo "  Where <platform> can be one of:"
+  echo -n "  "
+  echo $(ls toolchain | sed 's/\.config//g')
   exit 1
 fi
 
 #######################################################################################################################
 # Import common code and variables
-
-cd $(dirname ${0})
 
 source .common
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -6,9 +6,13 @@
 PLATFORM=${1}
 BUILDTARGET=${2}
 
-if [ -z "${PLATFORM}" ]; then
+cd $(dirname ${0})
+
+if [[ -z "${PLATFORM}" ]] || [[ ! -a "toolchain/${PLATFORM}.config" ]]; then
   echo "Usage: $0 <platform>"
-  echo "  Where platform can be modduo[-static], modduox[-static], moddwarf or x86_64"
+  echo "  Where <platform> can be one of:"
+  echo -n "  "
+  echo $(ls toolchain | sed 's/\.config//g')
   exit 1
 fi
 
@@ -22,8 +26,6 @@ fi
 
 #######################################################################################################################
 # Import common code and variables
-
-cd $(dirname ${0})
 
 source .common
 

--- a/build
+++ b/build
@@ -6,17 +6,19 @@
 PLATFORM=$1
 PACKAGE=$2
 
-if [[ "${PLATFORM}" == "" ]] || [[ "${PACKAGE}" == "" ]]; then
+cd $(dirname ${0})
+
+if [[ -z "${PLATFORM}" ]] || [[ ! -a "toolchain/${PLATFORM}.config" ]]; then
   echo "Usage: $0 <platform> <plugin-package-name>"
-  echo "  Where platform can be modduo[-static], modduox[-static], moddwarf or x86_64"
-  echo "  and plugin-package-name is a folder inside ./plugins/package"
+  echo "  Where <platform> can be one of:"
+  echo -n "  "
+  echo $(ls toolchain | sed 's/\.config//g')
+  echo "  and <plugin-package-name> is a folder inside ./plugins/package"
   exit 1
 fi
 
 #######################################################################################################################
 # Import common code and variables
-
-cd $(dirname ${0})
 
 source .common
 

--- a/docker-mount.sh
+++ b/docker-mount.sh
@@ -8,16 +8,19 @@ set -e
 PLATFORM="${1}"
 DOCKER_IMAGE="${2}"
 
-if [[ "${PLATFORM}" == "" ]] || [[ "${DOCKER_IMAGE}" == "" ]]; then
-  echo "Usage: $0 <platform> <docker-image>"
-  echo "  Where platform can be modduo[-static], modduox[-static], moddwarf or x86_64"
+cd $(dirname ${0})
+
+if [[ -z "${PLATFORM}" ]] || [[ ! -a "toolchain/${PLATFORM}.config" ]]; then
+  echo "Usage: $0 <platform>"
+  echo "  Where <platform> can be one of:"
+  echo -n "  "
+  echo $(ls toolchain | sed 's/\.config//g')
   exit 1
 fi
 
 #######################################################################################################################
 # Import common code and variables
 
-cd $(dirname ${0})
 source .common
 
 #######################################################################################################################

--- a/local.env
+++ b/local.env
@@ -10,15 +10,11 @@ WORKDIR=${WORKDIR:=~/mod-workdir}
 
 PLATFORM=$1
 
-if [ -z "${PLATFORM}" ]; then
-  echo "Usage: $0 <platform>"
-  echo "  Where platform can be modduo[-static], modduox[-static], moddwarf or x86_64"
-
-#######################################################################################################################
-
-elif [ "${PLATFORM}" != "modduo" ] && [ "${PLATFORM}" != "modduo-static" ] && [ "${PLATFORM}" != "modduox" ] && [ "${PLATFORM}" != "modduox-static" ] && [ "${PLATFORM}" != "moddwarf" ] && [ "${PLATFORM}" != "x86_64" ]; then
-  echo -e "\e[0;31mPlease provide either modduo, modduox, moddwarf or x86_64 as an argument to this env file\e[0m"
-
+if [[ -z "${PLATFORM}" ]] || [[ ! -a "./toolchain/${PLATFORM}.config" ]]; then
+  echo "Usage: . ./local.env <platform>"
+  echo "  Where <platform> can be one of:"
+  echo -n "  "
+  echo $(ls ./toolchain | sed 's/\.config//g')
 else
 
 #######################################################################################################################

--- a/publish
+++ b/publish
@@ -6,22 +6,19 @@
 PLATFORM=$1
 PACKAGE=$2
 
-if [[ "${PLATFORM}" == "" ]] || [[ "${PACKAGE}" == "" ]]; then
-    echo "Usage: $0 <platform> <plugin-package-name>"
-    echo "  Where platform can be modduo[-static], modduox[-static], moddwarf or x86_64"
-    echo "  and plugin-package-name is a folder inside ./plugins/package"
-    exit 1
-fi
+cd $(dirname ${0})
 
-if [ "${PLATFORM}" != "modduo" ] && [ "${PLATFORM}" != "modduo-static" ] && [ "${PLATFORM}" != "modduox" ] && [ "${PLATFORM}" != "modduox-static" ] && [ "${PLATFORM}" != "moddwarf" ] && [ "${PLATFORM}" != "x86_64" ]; then
-    echo -e "\e[0;31mPlease provide either modduo[-static], modduox[-static], moddwarf or x86_64 as platform argument\e[0m"
-    exit 1
+if [[ -z "${PLATFORM}" ]] || [[ ! -a "toolchain/${PLATFORM}.config" ]]; then
+  echo "Usage: $0 <platform> <plugin-package-name>"
+  echo "  Where <platform> can be one of:"
+  echo -n "  "
+  echo $(ls toolchain | sed 's/\.config//g')
+  echo "  and <plugin-package-name> is a folder inside ./plugins/package"
+  exit 1
 fi
 
 #######################################################################################################################
 # Import common code and variables
-
-cd $(dirname ${0})
 
 source .common
 

--- a/validate
+++ b/validate
@@ -6,22 +6,19 @@
 PLATFORM=$1
 PACKAGE=$2
 
-if [[ "${PLATFORM}" == "" ]] || [[ "${PACKAGE}" == "" ]]; then
-    echo "Usage: $0 <platform> <plugin-package-name>"
-    echo "  Where platform can be modduo[-static], modduox[-static], moddwarf or x86_64"
-    echo "  and plugin-package-name is a folder inside ./plugins/package"
-    exit 1
-fi
+cd $(dirname ${0})
 
-if [ "${PLATFORM}" != "modduo" ] && [ "${PLATFORM}" != "modduo-static" ] && [ "${PLATFORM}" != "modduox" ] && [ "${PLATFORM}" != "modduox-static" ] && [ "${PLATFORM}" != "moddwarf" ] && [ "${PLATFORM}" != "x86_64" ]; then
-    echo -e "\e[0;31mPlease provide either modduo, modduox, modduox-static, moddwarf or x86_64 as platform argument\e[0m"
+if [[ -z "${PLATFORM}" ]] || [[ ! -a "toolchain/${PLATFORM}.config" ]]; then
+    echo "Usage: $0 <platform> <plugin-package-name>"
+    echo "  Where <platform> can be one of:"
+    echo -n "  "
+    echo $(ls toolchain | sed 's/\.config//g')
+    echo "  and <plugin-package-name> is a folder inside ./plugins/package"
     exit 1
 fi
 
 #######################################################################################################################
 # Import common code and variables
-
-cd $(dirname ${0})
 
 source .common
 


### PR DESCRIPTION
This change gets the allowed platforms list from the .config files in
the toolchain directory, and uses that for the validation check, and
the help message.

This allows new platforms to be easily added.