### PR TITLE
Add ModularAmpToolKit

### DIFF
--- a/plugins/package/matk/matk.mk
+++ b/plugins/package/matk/matk.mk
@@ -4,7 +4,7 @@
 #
 ######################################
 
-MATK_VERSION = 838059558d590641ac861f662dd0e4745a096b2c
+MATK_VERSION = e7d026b15659c90259376cadda1297e628069451
 MATK_SITE = $(call github,brummer10,ModularAmpToolKit.lv2,$(MATK_VERSION))
 MATK_BUNDLES = PreAmps.lv2 PreAmpImpulses.lv2 poweramps.lv2 PowerAmpImpulses.lv2
 

--- a/plugins/package/matk/matk.mk
+++ b/plugins/package/matk/matk.mk
@@ -1,0 +1,25 @@
+######################################
+#
+# matk
+#
+######################################
+
+MATK_VERSION = 838059558d590641ac861f662dd0e4745a096b2c
+MATK_SITE = $(call github,brummer10,ModularAmpToolKit.lv2,$(MATK_VERSION))
+MATK_BUNDLES = PreAmps.lv2 PreAmpImpulses.lv2 poweramps.lv2 PowerAmpImpulses.lv2
+
+ifdef BR2_cortex_a7
+MATK_SSE_CFLAGS = -mfpu=vfpv3
+endif
+
+MATK_TARGET_MAKE = $(TARGET_MAKE_ENV) $(TARGET_CONFIGURE_OPTS) $(MAKE)  SSE_CFLAGS="$(MATK_SSE_CFLAGS)" -C $(@D)
+
+define MATK_BUILD_CMDS
+	$(MATK_TARGET_MAKE) mod
+endef
+
+define MATK_INSTALL_TARGET_CMDS
+	$(MATK_TARGET_MAKE) install DESTDIR=$(TARGET_DIR) INSTALL_DIR=/usr/lib/lv2
+endef
+
+$(eval $(generic-package))


### PR DESCRIPTION
ModularAmpToolKit is a set of 4 plugs, aims to simulate parts of a full guitar tube amplifier stack. 
PreAmpTubes -> simulate bar bone pre amplifier stack
PreAmpImpulses -> bar bone impulse response data set to shape the tone according the selected model
PowerAmpTubes -> simulate bar bone power amp stacks
PowerAmpImpulses -> bar bone impulse response data set to shape the tone according the selected model  