### PR TITLE
Add support for building docker images on Apple M1

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -33,7 +33,7 @@ RUN apt-get install -qy multiarch-support:armhf qemu-user-static && \
     apt-get install -qy libfreetype6-dev libx11-dev libxcursor-dev libxinerama-dev libxrandr-dev pkg-config && \
     apt-get clean
 RUN wget http://archive.ubuntu.com/ubuntu/pool/universe/p/premake/premake_3.7-1_amd64.deb && \
-    dpkg -i premake_3.7-1_amd64.deb && \
+    dpkg -i --force-architecture --force-depends premake_3.7-1_amd64.deb && \
     rm premake_3.7-1_amd64.deb
 
 RUN locale-gen en_US.UTF-8


### PR DESCRIPTION
I couldn't build the docker image on my machine.
Adding `dpkg -i --force-architecture --force-depends` fixed this. This might be an issue for other users on an Apple M1 machine aswell. 

This is not urgent or anything. Because I can add these lines and then everything works as expected on my machine.