### PR TITLE
Update dm-stutter.mk

### DIFF
--- a/plugins/package/dm-stutter/dm-stutter.mk
+++ b/plugins/package/dm-stutter/dm-stutter.mk
@@ -4,7 +4,7 @@
 #
 ######################################
 
-DM_STUTTER_VERSION = a2ce93bf9b36848c111c079a5e30382bc75f088c
+DM_STUTTER_VERSION = f965d9881e2d158472c5753061f66a1d96c10457
 DM_STUTTER_SITE = https://github.com/davemollen/dm-Stutter.git
 DM_STUTTER_SITE_METHOD = git
 DM_STUTTER_BUNDLES = dm-Stutter.lv2


### PR DESCRIPTION
This plugin is already in the stable store. So this needs an update. 
This update adds two CV trigger outputs to this plugin.